### PR TITLE
feat(website): show reading time

### DIFF
--- a/website/blog/fr/20210316-qui-a-invente-hypertexte.md
+++ b/website/blog/fr/20210316-qui-a-invente-hypertexte.md
@@ -1,5 +1,7 @@
 # Qui a inventé les ordis et l'hypertexte ?
 
+<div class="wc-text-content">
+
 ::: tip
 Infos complémentaires pour la chronique "Les anecdotes historiques" présentée durant [Les briques du Web S01E01](https://www.youtube.com/watch?v=czAx81Upp_U) le 16 mars 2021.
 :::
@@ -123,9 +125,11 @@ De l'aveu de Tim, son amour des petits trains a fortement contribué à sa passi
 
 En somme, nous pouvons donc affirmer sans détour que le Web n'aurait jamais vu le jour sans les petits trains !
 
-<hr style="margin-top: 5rem">
+<hr>
 
-<h2 style="text-align: center">Transcript de la chronique</h2>
+## Script de la chronique
+
+<div class="wc-text-content speak-time">
 
 Alors aujourd'hui, on va parler de la création du Web.\
 Allez, on commence par une question facile :\
@@ -218,3 +222,5 @@ En fait, rien de ce qu'on crée aujourd'hui n'est jamais véritablement "nouveau
 Derrières les "révolutions" et "disruptions" se cachent souvent un simple recyclage d'une vieille idée.
 
 De nombreuses idées, plus ou moins anciennes, attendent simplement leur "bon moment".
+
+</div>

--- a/website/blog/fr/20210405-as-we-may-think.md
+++ b/website/blog/fr/20210405-as-we-may-think.md
@@ -1,5 +1,7 @@
 # Vannevar Bush et la naissance des NTIC
 
+<div class="wc-text-content">
+
 ::: tip
 Infos complémentaires pour la chronique "Les anecdotes historiques" présentée durant [Les briques du Web S01E02](https://youtu.be/rI6xUkOnyB0?t=2621) le 30 mars 2021.
 :::
@@ -308,6 +310,8 @@ En 2021, la conclusion de Bush semble toujours d'actualité :
 >
 > Les applications de la science ont fourni à l’homme une maison bien équipée et elles lui apprennent à vivre sereinement. Elles lui ont permis de faire s’affronter des peuples avec des armes cruelles. Elles peuvent encore lui permettre de développer un savoir commun et de grandir dans la sagesse de l’expérience ainsi accumulée. L’humanité périra peut être dans un conflit avant d’apprendre à manier ce savoir pour le bien commun. Pourtant, dans l’application de la science aux besoins et aux désirs de l’homme, ce serait un bien mauvais moment pour interrompre ce processus, ou perdre espoir quant à son issue. »
 
+</div>
+
 ## Ressources
 
 - Vannevar Bush, « [As We May Think](https://www.theatlantic.com/magazine/archive/1945/07/as-we-may-think/303881/) », _The Atlantic_, juillet 1945
@@ -317,7 +321,11 @@ En 2021, la conclusion de Bush semble toujours d'actualité :
 - Pierre Musso, _[Critique des réseaux](https://www.cairn.info/critique-des-reseaux--9782130501374.htm)_, PUF, 2003
 - Paul N. Edwards, _[Un monde clos](https://editions-b2.com/les-livres/7-un-monde-clos.html)_, éditions B2, 2013 (texte original [publié aux MIT press](https://mitpress.mit.edu/books/closed-world) en 1996)
 
+<hr>
+
 ## Script de la chronique
+
+<div class="wc-text-content speak-time">
 
 Jingle\
 🎶 Père Noël, raconte nous des histoires 🎶\
@@ -478,3 +486,5 @@ Si vous être sur Youtube, les liens devraient se trouver ci-dessous.
 
 Merci à tous, à vous, le studios.
 (j'ai toujours rêvé de dire ça)
+
+</div>

--- a/website/blog/fr/20210413-histoire-rfc.md
+++ b/website/blog/fr/20210413-histoire-rfc.md
@@ -1,5 +1,7 @@
 # L'Histoire des _Request For Comments_
 
+<div class="wc-text-content">
+
 ::: tip
 Infos complémentaires pour :
 
@@ -208,6 +210,8 @@ Voici mes préférées :
 Enfin, je trouve que la [RFC8962](https://tools.ietf.org/html/rfc8962) est, cette année, particulièrement bienvenue et d'actualité.
 Il était grand temps que l'IETF fasse à son tour preuve d'autorité, en adoptant un régime policier !
 
+</div>
+
 ## Chronologie d'ARPAnet et des protocoles Internet
 
 ### 1958-1969 : fondations théoriques
@@ -295,7 +299,11 @@ Il était grand temps que l'IETF fasse à son tour preuve d'autorité, en adopta
 - Clark A. « Initial commit, based on Yarn RFCs repo · [reactjs/rfcs@59b512b](https://github.com/reactjs/rfcs/commit/59b512b) ». In : <em>GitHub</em>
 - Katz Y. <span>« Initial sketch of the RFC process · [yarnpkg/rfcs@8831cfa](https://github.com/yarnpkg/rfcs/commit/8831cfa) »</span>. In : <em>GitHub</em>
 
+<hr>
+
 ## Script de la chronique
+
+<div class="wc-text-content speak-time">
 
 Bon, déjà, faut qu'j'vous dise un truc.\
 C'est un truc qui me taraude depuis un moment, donc voila, je vide mon sac...
@@ -423,3 +431,5 @@ Pas sur ce que vous prétendez être.
 Votre boulot, votre position hiérarchique, votre violence, vos privilèges, bref, le pouvoir que vous avez de forcer les autres, n'est jamais pertinent.
 
 Pensez le contraire, et vous le payerez lourdement.
+
+</div>

--- a/website/src/app/pages.js
+++ b/website/src/app/pages.js
@@ -27,7 +27,7 @@ function uid() {
 /**
  * @param {Element} root
  */
-async function responsiveTables(root) {
+function responsiveTables(root) {
   const tables = root.querySelectorAll("table");
   if (tables.length < 1) return;
   const style = document.createElement("style");
@@ -58,7 +58,28 @@ async function responsiveTables(root) {
 /**
  * @param {Element} root
  */
+function addReadingTime(root) {
+  const texts = root.querySelectorAll(".wc-text-content");
+  for (const text of texts) {
+    const words = text.innerHTML
+      .replace(/<[^>]*>/g, " ")
+      .replace(/\s+/g, " ")
+      .trim()
+      .split(" ");
+    const wordsPerMinute = text.classList.contains("speak-time") ? 160 : 250;
+    const readingTime = Math.round(words.length / wordsPerMinute);
+    const readingTimeEl = document.createElement("p");
+    readingTimeEl.classList.add("reading-time");
+    readingTimeEl.textContent = `${readingTime} minutes`;
+    text.prepend(readingTimeEl);
+  }
+}
+
+/**
+ * @param {Element} root
+ */
 export async function stylePage(root) {
   await codeStyle(root);
-  await responsiveTables(root);
+  responsiveTables(root);
+  addReadingTime(root);
 }

--- a/website/src/styles/daucus-pages.scss
+++ b/website/src/styles/daucus-pages.scss
@@ -49,9 +49,25 @@
   hr {
     border: 0;
     border-top: 1px solid var(--neutral-color-300);
+    margin-top: 5rem;
+    margin-bottom: 2rem;
   }
   [align="center"] {
     text-align: center !important;
+  }
+
+  .reading-time {
+    padding: 0rem 0 1rem 3rem;
+    color: #666;
+  }
+
+  .reading-time::before {
+    content: "⏲";
+    padding-right: 1rem;
+  }
+
+  .speak-time .reading-time::before {
+    content: "🗣"
   }
 
   @media screen and (max-width: 719px) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Affected packages

<!-- put an `x` in all the boxes that apply -->

- [x] website
- [ ] Daucus
- [ ] Helpers
- [ ] codelabs
- [ ] illustrations
- [ ] benchmarks
- [ ] code-samples
- [ ] presentations/conferences
- [ ] custom-element-name
- [ ] demos
- [ ] other: .....

## Description

Calculate and display daucus pages reading time.

## Screenshots (if appropriate):

![screenshot](https://user-images.githubusercontent.com/7578400/117134893-7db32180-ada6-11eb-966c-3cbf8130c986.png)
