### PR TITLE
Daucus reverse menu

### DIFF
--- a/packages/daucus/cli/daucus-config.schema.json
+++ b/packages/daucus/cli/daucus-config.schema.json
@@ -43,6 +43,10 @@
           },
           "type": "array"
         },
+        "reverseMenu": {
+          "description": "Reverse menu entries.",
+          "type": "boolean"
+        },
         "root": {
           "description": "The root of the source files.",
           "type": "string"

--- a/packages/daucus/cli/src/compilers/build.js
+++ b/packages/daucus/cli/src/compilers/build.js
@@ -177,7 +177,10 @@ export async function buildProject(
         })
       );
 
-      routesConfigBuilder.complete(htmlMinifierOptions);
+      routesConfigBuilder.complete(
+        htmlMinifierOptions,
+        projectConfig.reverseMenu
+      );
       /** @type {[LanguageCodeOrDefault, ProjectRoutesConfig]} */
       const config = [lang || "__", routesConfigBuilder.config];
       return config;

--- a/packages/daucus/cli/src/config/DaucusConfig.d.ts
+++ b/packages/daucus/cli/src/config/DaucusConfig.d.ts
@@ -38,6 +38,11 @@ export interface ProjectConfig {
    * Use file name as menu title instead of first h1
    */
   usePathAsTitle?: boolean;
+
+  /**
+   * Reverse menu entries.
+   */
+  reverseMenu?: boolean;
 }
 
 /**

--- a/packages/daucus/cli/src/routing/menu.js
+++ b/packages/daucus/cli/src/routing/menu.js
@@ -4,13 +4,13 @@
 import { sortRoutesChildEntriesByPosition } from "./sort.js";
 
 /**
- *
  * @param {ProjectRoutesConfig} routes
  * @param {string} projectName
+ * @param {boolean} [reverse]
  *
  * @returns {string} HTML template
  */
-export function menuTemplate(routes, projectName) {
+export function menuTemplate(routes, projectName, reverse) {
   /**
    *
    * @param {ProjectRoutesConfig} route
@@ -20,6 +20,17 @@ export function menuTemplate(routes, projectName) {
    * @returns {string}
    */
   function menu(route, depth, routeName) {
+    /** @type {[string, import('@daucus/core').RouteWithChildren][]} */
+    let sortedChildren = [];
+    if (route.children) {
+      sortedChildren = Object.entries(route.children).sort(
+        sortRoutesChildEntriesByPosition
+      );
+      if (reverse) {
+        sortedChildren.reverse();
+      }
+    }
+
     return `
       <div class="${depth === 0 ? "menu-title" : ""} section-title">
         ${
@@ -37,8 +48,7 @@ export function menuTemplate(routes, projectName) {
               (depth > 0 ? "child-menu" : "menu") +
               (route.path === undefined ? " collapsible" : "")
             }">
-              ${Object.entries(route.children)
-                .sort(sortRoutesChildEntriesByPosition)
+              ${sortedChildren
                 .map(
                   ([childRouteName, childRoute]) =>
                     `<li>

--- a/packages/daucus/cli/src/routing/route-config.js
+++ b/packages/daucus/cli/src/routing/route-config.js
@@ -70,10 +70,11 @@ export class ProjectRoutesConfigBuilder {
 
   /**
    * @param {HTMLMin.Options} htmlMinifierOptions
+   * @param {boolean} [reverse]
    */
-  complete(htmlMinifierOptions) {
+  complete(htmlMinifierOptions, reverse) {
     this._projectRoutesConfig.menu = HTMLMin.minify(
-      menuTemplate(this._projectRoutesConfig, this._projectName),
+      menuTemplate(this._projectRoutesConfig, this._projectName, reverse),
       htmlMinifierOptions
     );
     this._isComplete = true;

--- a/packages/daucus/cli/test-node/fixtures/index.js
+++ b/packages/daucus/cli/test-node/fixtures/index.js
@@ -13,6 +13,7 @@ import { DaucusCLI } from "../../src/cli/DaucusCLI.js";
  */
 export const configs = {
   default: resolve(esmDirName(import.meta), "default", "daucus.config.json"),
+  reverse: resolve(esmDirName(import.meta), "reverse", "daucus.config.json"),
   i18n: resolve(esmDirName(import.meta), "i18n", "daucus.config.json"),
   jsConfig: resolve(esmDirName(import.meta), "js-config", "daucus.config.js"),
   snarkdown: resolve(

--- a/packages/daucus/cli/test-node/fixtures/reverse/_snapshots_/routes.js
+++ b/packages/daucus/cli/test-node/fixtures/reverse/_snapshots_/routes.js
@@ -1,0 +1,57 @@
+export default {
+  docs: {
+    children: {
+      "hello-world": {
+        id: "hello-world",
+        position: "",
+        path: "hello-world",
+        templateUrl: "hello-world.html",
+        title: "Hello World!",
+      },
+      "second-part": {
+        children: {
+          "another-file": {
+            id: "0b-another-file",
+            position: "0b",
+            path: "second-part/another-file",
+            templateUrl: "02-second-part/0b-another-file.html",
+            title: "Another file",
+          },
+          "first-file": {
+            id: "01-first-file",
+            position: "01",
+            path: "second-part/first-file",
+            templateUrl: "02-second-part/01-first-file.html",
+            title: "First file",
+          },
+        },
+        id: "",
+        position: "02",
+        path: "second-part",
+        templateUrl: "02-second-part/index.html",
+        title: "Second Part",
+      },
+      "after-first-part": {
+        id: "",
+        position: "01a",
+        path: "after-first-part",
+        templateUrl: "01a-after-first-part/README.html",
+        title: "Inbetween",
+      },
+      "first-part": {
+        id: "",
+        position: "01",
+        path: "first-part",
+        templateUrl: "01-first-part/index.html",
+        title: "",
+      },
+    },
+    id: "",
+    position: "",
+    path: "",
+    templateUrl: "README.html",
+    title: "Pages project",
+    menu:
+      '<div class="section-title menu-title"><a href=/docs/ >Pages project</a></div><ul class=menu><li><div class=section-title><a href=/docs/hello-world>Hello World!</a></div><li><div class=section-title><a href=/docs/second-part>Second Part</a></div><ul class=child-menu><li><div class=section-title><a href=/docs/second-part/another-file>Another file</a></div><li><div class=section-title><a href=/docs/second-part/first-file>First file</a></div></ul><li><div class=section-title><button aria-label=first-part role=button>first-part</button></div><li><div class=section-title><a href=/docs/after-first-part>Inbetween</a></div></ul>',
+  },
+};

--- a/packages/daucus/cli/test-node/fixtures/reverse/daucus.config.json
+++ b/packages/daucus/cli/test-node/fixtures/reverse/daucus.config.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../../daucus-config.schema.json",
+  "projects": {
+    "docs": {
+      "root": "docs",
+      "src": "**/*.md",
+      "reverseMenu": true
+    }
+  }
+}

--- a/packages/daucus/cli/test-node/fixtures/reverse/docs/01-first-part/index.md
+++ b/packages/daucus/cli/test-node/fixtures/reverse/docs/01-first-part/index.md
@@ -1,0 +1,3 @@
+## substitle
+
+> Nothing here...

--- a/packages/daucus/cli/test-node/fixtures/reverse/docs/01a-after-first-part/README.md
+++ b/packages/daucus/cli/test-node/fixtures/reverse/docs/01a-after-first-part/README.md
@@ -1,0 +1,3 @@
+# Inbetween
+
+Lorem ipsum

--- a/packages/daucus/cli/test-node/fixtures/reverse/docs/02-second-part/01-first-file.md
+++ b/packages/daucus/cli/test-node/fixtures/reverse/docs/02-second-part/01-first-file.md
@@ -1,0 +1,1 @@
+# First file

--- a/packages/daucus/cli/test-node/fixtures/reverse/docs/02-second-part/0b-another-file.md
+++ b/packages/daucus/cli/test-node/fixtures/reverse/docs/02-second-part/0b-another-file.md
@@ -1,0 +1,3 @@
+# Another file
+
+Lorem ipsum

--- a/packages/daucus/cli/test-node/fixtures/reverse/docs/02-second-part/index.md
+++ b/packages/daucus/cli/test-node/fixtures/reverse/docs/02-second-part/index.md
@@ -1,0 +1,3 @@
+# Second Part
+
+[first part](./01-first-file.md)

--- a/packages/daucus/cli/test-node/fixtures/reverse/docs/README.md
+++ b/packages/daucus/cli/test-node/fixtures/reverse/docs/README.md
@@ -1,0 +1,1 @@
+# Pages project

--- a/packages/daucus/cli/test-node/fixtures/reverse/docs/hello-world.md
+++ b/packages/daucus/cli/test-node/fixtures/reverse/docs/hello-world.md
@@ -1,0 +1,1 @@
+# Hello World!

--- a/packages/daucus/cli/test-node/src/commands/build.test.js
+++ b/packages/daucus/cli/test-node/src/commands/build.test.js
@@ -40,6 +40,20 @@ describe("BuildCommand", () => {
     expect(routes.config).to.deep.equal(routes.snapshot);
   });
 
+  it("can reverse menu entries", async () => {
+    const wp = await fixtureWorkspace("reverse");
+    const cmd = new BuildCommand(wp);
+
+    await cmd.run();
+
+    const { output, config } = await workspaceInfos(wp);
+
+    expect(config.defaultCompiler).to.not.be.ok;
+
+    const routes = await output.routes();
+    expect(routes.config).to.deep.equal(routes.snapshot);
+  });
+
   it("handle i18n", async () => {
     const wp = await fixtureWorkspace("i18n");
     const cmd = new BuildCommand(wp);

--- a/website/daucus.config.mjs
+++ b/website/daucus.config.mjs
@@ -14,6 +14,7 @@ const config = {
     blog: {
       src: "**/*.md",
       root: "blog",
+      reverseMenu: true,
     },
     daucus: {
       src: "**/*.md",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Affected packages

<!-- put an `x` in all the boxes that apply -->

- [x] website
- [x] Daucus
- [ ] Helpers
- [ ] codelabs
- [ ] illustrations
- [ ] benchmarks
- [ ] code-samples
- [ ] presentations/conferences
- [ ] custom-element-name
- [ ] demos
- [ ] other: .....

## Description

new projects.reverseMenu boolean option to reverse order of menu entries
when set to true

## Motivation and Context

By default, dates prefixes are ordered by alphabetical order (oldest to latest).
The blog menu entries should be orderred from latest to oldest.

## How Has This Been Tested?

<!--- ✍️ Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

https://fullweb.dev/blog/revolution-khtml

Before: 

![](https://user-images.githubusercontent.com/7578400/117227343-e5a15080-ae16-11eb-8fc8-72356f993f19.png)

After:

![](https://user-images.githubusercontent.com/7578400/117227425-108ba480-ae17-11eb-9547-31bd11de1489.png)


## Types of changes

<!--- ✍️ What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
