### PR TITLE
fix(website): update shell lang on navigation

### DIFF
--- a/website/src/app/router.js
+++ b/website/src/app/router.js
@@ -411,6 +411,7 @@ export class AppRouter extends AbstractRouter {
       return [`/${this.preferredLanguage}${path}`, { ...options }];
     }
     const [, lang, pathWithoutLang = "/"] = langMatchInPath;
+    const langHasChanged = this.preferredLanguage !== lang;
     this._forcedLanguage = /** @type {Language} */ (lang);
     const {
       staticContent,
@@ -492,6 +493,10 @@ export class AppRouter extends AbstractRouter {
 
     if (templateLang) {
       this.outlet.lang = templateLang;
+    }
+
+    if (langHasChanged) {
+      this.dispatchEvent(new CustomEvent("lang-changed"));
     }
 
     return null;

--- a/website/src/app/shell.js
+++ b/website/src/app/shell.js
@@ -57,6 +57,10 @@ export class AppShell {
       this.querySelector("#standard-menu").style.display = "none";
     });
 
+    router.addEventListener("lang-changed", () => {
+      this.updateShellLang();
+    });
+
     router.addEventListener("daucus-route-matched", (e) => {
       this._updateDaucusMenu(/** @type {DaucusRouteMatchedEvent} */ (e));
       this._updateAppMenu(/** @type {AppRouteMatchedEvent} */ (e));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Affected packages

<!-- put an `x` in all the boxes that apply -->

- [x] website
- [ ] Daucus
- [ ] Helpers
- [ ] codelabs
- [ ] illustrations
- [ ] benchmarks
- [ ] code-samples
- [ ] presentations/conferences
- [ ] custom-element-name
- [ ] demos
- [ ] other: .....

## Description

Update app shell wordings when navigating to a path with a different language than the selected one.

## Motivation and Context

The router wasn't notifying the shell to update its language when navigating to a path specifying a different language (i.e. /fr/ or
/en/) than the previously selected one.

This caused an inconsistency between the language used for content and for the app shell, especially when navigating through the history (i.e. "back" button) after the preferred language was changed.

## Types of changes

<!--- ✍️ What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
