### PR TITLE
Lit 2 upgrade - step 1 (website & code-samples)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,6 +90,16 @@ Then, you'll need to install the dependencies for the whole monorepo by running 
 
 Finally, you can run the standalone website, without building any other packages, by going to the [/website](./website) directory and running `npm start`.
 
+## :warning: Quirks
+
+### Daucus
+
+#### Snowpack-template
+
+When testing the Daucus Snowpack Template package (e.g. using `npm run lerna -- run start --scope "@daucus/snowpack-template"`), you need to specify the Snowpack `workspaceRoot` (i.e. add `workspaceRoot: "../../../"` to `packages/daucus/snowpack-template/snowpack.config.js`).
+
+See the [Snowpack documentation](https://www.snowpack.dev/reference/configuration#workspaceroot) for more information.
+
 ## <a name="styleguides"></a> Styleguides
 
 ### <a name="commit"></a> Commit Message Format

--- a/materials/code-samples/src/libs/lit-element/async-helloworld.js
+++ b/materials/code-samples/src/libs/lit-element/async-helloworld.js
@@ -9,7 +9,7 @@ import {
   LitElement,
   html,
   css,
-} from "https://cdn.skypack.dev/lit-element@2.4.0";
+} from "https://cdn.skypack.dev/lit@2.0.0-rc.2";
 
 class AsyncHelloWorld extends LitElement {
   //#region styles

--- a/materials/code-samples/src/libs/lit-element/helloworld.js
+++ b/materials/code-samples/src/libs/lit-element/helloworld.js
@@ -2,7 +2,7 @@
 import {
   LitElement,
   html,
-} from "https://cdn.skypack.dev/lit-element@2.4.0";
+} from "https://cdn.skypack.dev/lit@2.0.0-rc.2";
 
 //#region component
 class HelloWorld extends LitElement {

--- a/materials/code-samples/src/libs/lit-element/importmap/async-helloworld.js
+++ b/materials/code-samples/src/libs/lit-element/importmap/async-helloworld.js
@@ -6,7 +6,7 @@
  */
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { LitElement, html, css } from "lit-element";
+import { LitElement, html, css } from "lit";
 
 class AsyncHelloWorld extends LitElement {
   //#region styles

--- a/materials/code-samples/src/libs/lit-element/importmap/index.html
+++ b/materials/code-samples/src/libs/lit-element/importmap/index.html
@@ -5,10 +5,9 @@
     <title>lit-element - hello world</title>
   </head>
   <body>
-    <h1>lit-element - hello world</h1>
-    <h2>basic</h2>
-    <fwd-helloworld></fwd-helloworld>
-    <h2>async</h2>
+    <h1>
+      lit-element - async hello world with es-module-shims
+    </h1>
     <fwd-async-hw></fwd-async-hw>
     <script
       type="module-shim"
@@ -17,10 +16,8 @@
     <script type="importmap-shim">
       {
         "imports": {
-          "lit-html/": "https://cdn.skypack.dev/lit-html@1.3.0/",
-          "lit-html": "https://cdn.skypack.dev/lit-html@1.3.0",
-          "lit-element/": "https://cdn.skypack.dev/lit-element@2.4.0/",
-          "lit-element": "https://cdn.skypack.dev/lit-element@2.4.0"
+          "lit/": "https://cdn.skypack.dev/lit@2.0.0-rc.2/",
+          "lit": "https://cdn.skypack.dev/lit@2.0.0-rc.2"
         }
       }
     </script>

--- a/materials/code-samples/src/libs/lit-element/promise-helloworld.js
+++ b/materials/code-samples/src/libs/lit-element/promise-helloworld.js
@@ -2,9 +2,9 @@ import {
   LitElement,
   html,
   css,
-} from "https://cdn.skypack.dev/lit-element@2.4.0";
+} from "https://cdn.skypack.dev/lit@2.0.0-rc.2";
 // FIXME: duplicated dependency
-import { until } from "https://cdn.skypack.dev/lit-html@1.3.0/directives/until.js";
+import { until } from "https://cdn.skypack.dev/lit@2.0.0-rc.2/directives/until.js";
 
 function loadMsg() {
   return new Promise((resolve) => {

--- a/website/package.json
+++ b/website/package.json
@@ -52,8 +52,7 @@
     "@modern-helpers/el": "*",
     "@modern-helpers/router": "*",
     "custom-element-name": "*",
-    "lit-element": "^2.4.0",
-    "lit-html": "^1.3.0",
+    "lit": "~2.0.0-rc.2",
     "prismjs": "^1.21.0"
   }
 }

--- a/website/src/app/views/ce-name.js
+++ b/website/src/app/views/ce-name.js
@@ -1,7 +1,7 @@
 /* eslint-disable max-classes-per-file */
-import { LitElement, html, css } from "lit-element";
-import { unsafeHTML } from "lit-html/directives/unsafe-html";
-import { live } from "lit-html/directives/live";
+import { LitElement, html, css } from "lit";
+import { unsafeHTML } from "lit/directives/unsafe-html.js";
+import { live } from "lit/directives/live.js";
 import {
   validateAndCreateElement,
   InvalidElementNameError,
@@ -14,7 +14,7 @@ export const selector = "app-ce-name";
 class CENameTestElement extends LitElement {
   static get properties() {
     return {
-      _msg: { type: String, attribute: false },
+      _msg: { type: String, state: true },
       lang: { type: String },
       wording: { type: Object, attribute: false },
       value: { type: String },

--- a/website/src/app/views/projects-list.js
+++ b/website/src/app/views/projects-list.js
@@ -1,6 +1,6 @@
-import { LitElement, html, css } from "lit-element";
-import { ifDefined } from "lit-html/directives/if-defined.js";
-import { classMap } from "lit-html/directives/class-map.js";
+import { LitElement, html, css } from "lit";
+import { ifDefined } from "lit/directives/if-defined.js";
+import { classMap } from "lit/directives/class-map.js";
 
 export const selector = "app-projects-list";
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Affected packages

<!-- put an `x` in all the boxes that apply -->

- [x] website
- [ ] Daucus
- [ ] Helpers
- [ ] codelabs
- [ ] illustrations
- [ ] benchmarks
- [x] code-samples
- [ ] presentations/conferences
- [ ] custom-element-name
- [ ] demos
- [ ] other: .....

## Description

Remplace `lit-html` and `lit-element` dependencies by Lit 2.0 (RC 2) in website and code-samples.

## Motivation and Context

See the [Lit Upgrade Guide](https://lit.dev/docs/releases/upgrade/) & the [RC 1 announcement](https://lit.dev/blog/2021-04-21-lit-2.0-meet-lit-all-over-again/).

This address #79 for the most part (as the website and code samples are the only parts of this project to fully use Lit) but not entirely. Upgrade in other projects will be done later as underlying tools don't fully support Lit 2 yet.