### PR TITLE
hotfix(website): don't cache homepage template from localized index

### DIFF
--- a/website/src/app/router.js
+++ b/website/src/app/router.js
@@ -513,7 +513,6 @@ export class AppRouter extends AbstractRouter {
     const initialContent = pageContainer.childNodes;
     const fragment = document.createDocumentFragment();
     fragment.append(...initialContent);
-    this._appRoutes["/"].template = () => fragment.cloneNode(true);
 
     pageContainer.innerHTML = "";
     pageContainer.appendChild(this.outlet);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Affected packages

<!-- put an `x` in all the boxes that apply -->

- [x] website
- [ ] Daucus
- [ ] Helpers
- [ ] codelabs
- [ ] illustrations
- [ ] benchmarks
- [ ] code-samples
- [ ] presentations/conferences
- [ ] custom-element-name
- [ ] demos
- [ ] other: .....

## Description

Avoid caching the homepage template from the static localized index file as it breaks language switch.

## Motivation and Context

close #104

## Types of changes

<!--- ✍️ What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)