### PR TITLE
code-samples: show the Lit demo using the until directive

### DIFF
--- a/materials/code-samples/src/libs/lit-element/index.html
+++ b/materials/code-samples/src/libs/lit-element/index.html
@@ -10,6 +10,10 @@
     <fwd-helloworld></fwd-helloworld>
     <h2>async</h2>
     <fwd-async-hw></fwd-async-hw>
+    <h2>
+      promise (using the <code>until</code> directive)
+    </h2>
+    <fwd-promise-hw></fwd-promise-hw>
     <script type="module" src="index.js"></script>
   </body>
 </html>

--- a/materials/code-samples/src/libs/lit-element/index.js
+++ b/materials/code-samples/src/libs/lit-element/index.js
@@ -1,2 +1,3 @@
 import "./helloworld.js";
 import "./async-helloworld.js";
+import "./promise-helloworld.js";

--- a/materials/code-samples/src/libs/lit-element/promise-helloworld.js
+++ b/materials/code-samples/src/libs/lit-element/promise-helloworld.js
@@ -3,7 +3,6 @@ import {
   html,
   css,
 } from "https://cdn.skypack.dev/lit@2.0.0-rc.2";
-// FIXME: duplicated dependency
 import { until } from "https://cdn.skypack.dev/lit@2.0.0-rc.2/directives/until.js";
 
 function loadMsg() {
@@ -11,12 +10,12 @@ function loadMsg() {
     setInterval(resolve, 3000, "Hello World!");
   });
 }
-class AsyncHelloWorld extends LitElement {
+class PromiseHelloWorld extends LitElement {
   //#region styles
   static get styles() {
     return css`
       p {
-        color: red;
+        color: green;
       }
     `;
   }
@@ -39,10 +38,9 @@ class AsyncHelloWorld extends LitElement {
 
   //#region render
   render() {
-    // FIXME: doesn't render the expected output
-    return html`${until(this.message, "loading")}`;
+    return html`<p>${until(this.message, "Loading")}</p>`;
   }
   //#endregion render
 }
 
-customElements.define("fwd-promise-hw", AsyncHelloWorld);
+customElements.define("fwd-promise-hw", PromiseHelloWorld);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Affected packages

<!-- put an `x` in all the boxes that apply -->

- [ ] website
- [ ] Daucus
- [ ] Helpers
- [ ] codelabs
- [ ] illustrations
- [ ] benchmarks
- [x] code-samples
- [ ] presentations/conferences
- [ ] custom-element-name
- [ ] demos
- [ ] other: .....

## Description

Add the previously broken demo to the associated index.html, as using Lit 2 fixed it.

## Motivation and Context

see #105
close #50
