### PR TITLE
fix(daucus-cli): i18n root directory on watch

### DIFF
--- a/packages/daucus/cli/src/compilers/i18n.js
+++ b/packages/daucus/cli/src/compilers/i18n.js
@@ -43,7 +43,7 @@ export function getLangFromPath(filePath, root) {
   /** @type {LanguageCode} */
   // prettier-ignore
   const rootDirName = (/** @type {LanguageCode} */ relativeFilePath.split(
-    path.delimiter
+    path.sep
   )[0]);
   if (!rootDirName || !rootDirName.match(ISO639_1_REGEXP)) {
     return "";


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Affected packages

<!-- put an `x` in all the boxes that apply -->

- [ ] website
- [x] Daucus
- [ ] Helpers
- [ ] codelabs
- [ ] illustrations
- [ ] benchmarks
- [ ] code-samples
- [ ] presentations/conferences
- [ ] custom-element-name
- [ ] demos
- [ ] other: .....

## Description

When using the watch mode on an i18n project, use "project/lang/" instead of "project/" as the root directory when re-compiling a changed file (for consistency with the first compilation).

## Motivation and Context

This wrong behavior was causing rebuild to fail when specifying the path to a bibliographic data file for Pandoc (`--bibliography` option), as `resource-path` was inconsistent.

## Types of changes

<!--- ✍️ What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
