### PR TITLE
fix(website): move footer to main content

### DIFF
--- a/website/public/styles/shell_large.css
+++ b/website/public/styles/shell_large.css
@@ -87,11 +87,9 @@
   max-height: calc(100vh - 6rem - 135px);
 }
 
-/* 936px (max-with of #page-container) + 2 * (250px (width of #daucus-menu) + 3rem (padding)) */
-@media screen and (min-width: 1533px) {
-  #standard-menu {
-    padding-left: 0;
-  }
+.daucus-page ~ #main-footer {
+  /* full width - standard menu */
+  width: calc(100vw - 250px - 3rem);
 }
 
 /*#endregion content */

--- a/website/templates/index/shell.css
+++ b/website/templates/index/shell.css
@@ -62,7 +62,8 @@ body {
   padding: 2rem 1rem;
   position: absolute;
   bottom: 0;
-  width: calc(100% - 2rem);
+  width: 100%;
+  box-sizing: border-box;
   font-size: 15px;
 }
 

--- a/website/templates/index/template.html
+++ b/website/templates/index/template.html
@@ -277,18 +277,18 @@
                 <div class="spinner__double-bounce1"></div>
                 <div class="spinner__double-bounce2"></div>
               </div>
+              <footer id="main-footer">
+                <div class="language-switch">
+                  {{#language.switch}}{{{language.switch}}}{{/language.switch}}
+                </div>
+                <div class="footer__license">
+                  {{#language.copyright}}{{{&language.copyright}}}{{/language.copyright}}
+                </div>
+              </footer>
             </div>
           </div>
         </main>
       </div>
-      <footer id="main-footer">
-        <div class="language-switch">
-          {{#language.switch}}{{{language.switch}}}{{/language.switch}}
-        </div>
-        <div class="footer__license">
-          {{#language.copyright}}{{{&language.copyright}}}{{/language.copyright}}
-        </div>
-      </footer>
     </div>
     <script type="module">
       import { App } from "/dist/app/index.js";


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Affected packages

<!-- put an `x` in all the boxes that apply -->

- [x] website
- [ ] Daucus
- [ ] Helpers
- [ ] codelabs
- [ ] illustrations
- [ ] benchmarks
- [ ] code-samples
- [ ] presentations/conferences
- [ ] custom-element-name
- [ ] demos
- [ ] other: .....

## Description

when showing a daucus page with a menu, the main footer and the menu should not overlap

## Motivation and Context

close #122

## Screenshots (if appropriate):

![screenshot showing the footer menu in the main content](https://user-images.githubusercontent.com/7578400/197525745-a3c24e3e-ed83-46de-a5cc-6f20b5bac6c7.png)

## Types of changes

<!--- ✍️ What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
