### PR TITLE
fix(website): CV dark theme

### DIFF
--- a/website/public/styles/dark-theme.css
+++ b/website/public/styles/dark-theme.css
@@ -22,5 +22,6 @@ html {
   --soft-bg-color: #0d1117;
   --stronger-bg-color: var(--neutral-color-300);
   --daucus-menu-active-color: var(--primary-color);
+  --light-item-inversion: 1;
   font-size: 16px;
 }

--- a/website/public/styles/light-theme.css
+++ b/website/public/styles/light-theme.css
@@ -22,5 +22,6 @@ html {
   --soft-bg-color: var(--neutral-color-100);
   --stronger-bg-color: var(--neutral-color-300);
   --daucus-menu-active-color: var(--primary-color);
+  --light-item-inversion: 0;
   font-size: 16px;
 }

--- a/website/src/app/views/cv-nma.js
+++ b/website/src/app/views/cv-nma.js
@@ -144,6 +144,10 @@ const timelineStyle = css`
     box-sizing: border-box;
   }
 
+  .light-icon {
+    filter: invert(var(--light-item-inversion, 0));
+  }
+
   .timeline {
     display: flex;
     flex-direction: column;
@@ -212,7 +216,6 @@ const timelineStyle = css`
   }
   .timeline__event__content {
     padding: 0.7rem 1rem 0.5rem 1rem;
-    background: #fff;
     border-radius: 0 6px 6px 0;
     flex-grow: 1;
     border: 1px solid var(--primary-color);
@@ -711,8 +714,11 @@ export default class NMACVElement extends LitElementWithCVNMAWording {
                           rel="noreferrer noopener"
                           class="invisible-link"
                           ><li class="networks__item">
-                            <img src=${item.icon} alt=${item.alt} /><span
-                              class="networks__item__content"
+                            <img
+                              src=${item.icon}
+                              alt=${item.alt}
+                              class="light-icon"
+                            /><span class="networks__item__content"
                               >${item.text}</span
                             >
                           </li></a
@@ -740,7 +746,7 @@ export default class NMACVElement extends LitElementWithCVNMAWording {
             ({ title, content, icon }) => html` <div class="cv__intro__item">
               <div class="cv__intro__item__header">
                 <div class="icon-container">
-                  <img class="icon" src=${icon.src} alt="" />
+                  <img class="icon light-icon" src=${icon.src} alt="" />
                 </div>
                 <div class="title-container">
                   <div class="category">${icon.caption}</div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Affected packages

<!-- put an `x` in all the boxes that apply -->

- [x] website
- [ ] Daucus
- [ ] Helpers
- [ ] codelabs
- [ ] illustrations
- [ ] benchmarks
- [ ] code-samples
- [ ] presentations/conferences
- [ ] custom-element-name
- [ ] demos
- [ ] other: .....

## Description

adapt the style of the CV view to look good when using the dark theme

## Motivation and Context

follow https://github.com/fullwebdev/fullwebdev/pull/144

## Screenshots (if appropriate):

### After
![image](https://user-images.githubusercontent.com/7578400/198351043-11ac3250-1d8e-4f36-a65d-227cc55947b8.png)

### Before
![image](https://user-images.githubusercontent.com/7578400/198351122-8c4417d6-e177-4d53-a91c-7e79ca6574b7.png)


## Types of changes

<!--- ✍️ What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
