### PR TITLE
build(website): rollback to snowpack 3.7

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -45,7 +45,7 @@
     "minify-html-literals": "^1.3.2",
     "mustache": "^4.1.0",
     "sass": "^1.32.7",
-    "snowpack": "^3.0.11",
+    "snowpack": "~3.7.0",
     "terser": "^4.8.0"
   },
   "dependencies": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Affected packages

<!-- put an `x` in all the boxes that apply -->

- [x] website
- [ ] Daucus
- [ ] Helpers
- [ ] codelabs
- [ ] illustrations
- [ ] benchmarks
- [ ] code-samples
- [ ] presentations/conferences
- [ ] custom-element-name
- [ ] demos
- [ ] other: .....

## Description

use Snowpack 3.7 instead of 3.8

## Motivation and Context

due to an issue snowpack 3.8 has with circular dependencies, the website dev server (npm start) didn't work anymore ("Unscannable package import found" error with files like lit-html/directives/style-map.js)

see https://github.com/lit/lit/issues/2198#issuecomment-940997011